### PR TITLE
Upgrade to reserved instances pricing v2

### DIFF
--- a/ec2-windows.gs
+++ b/ec2-windows.gs
@@ -6,7 +6,7 @@
  * @customfunction
  */
 function EC2_WINDOWS_OD(type, region) {
-  return get_ec2_od_price(type, region, "http://a0.awsstatic.com/pricing/1/ec2/mswin-od.min.js");
+  return get_ec2_od_price(type, region, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/windows-shared.min.js");
 }
 
 /**
@@ -19,7 +19,7 @@ function EC2_WINDOWS_OD(type, region) {
  */
 function EC2_WINDOWS_RI_LIGHT_AD(type, region, term) {
   if(!term) term = 1
-  return get_ec2_ri_price(type, region, term, false, "http://a0.awsstatic.com/pricing/1/ec2/mswin-ri-light.min.js");
+  return get_ec2_ri_price(type, region, term, false, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/windows-shared.min.js", "noUpfront");
 }
 
 /**
@@ -32,7 +32,7 @@ function EC2_WINDOWS_RI_LIGHT_AD(type, region, term) {
  */
 function EC2_WINDOWS_RI_MEDIUM_AD(type, region, term) {
   if(!term) term = 1
-  return get_ec2_ri_price(type, region, term, false, "http://a0.awsstatic.com/pricing/1/ec2/mswin-ri-medium.min.js");
+  return get_ec2_ri_price(type, region, term, false, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/windows-shared.min.js", "partialUpfront");
 }
 
 /**
@@ -45,7 +45,7 @@ function EC2_WINDOWS_RI_MEDIUM_AD(type, region, term) {
  */
 function EC2_WINDOWS_RI_HEAVY_AD(type, region, term) {
   if(!term) term = 1
-  return get_ec2_ri_price(type, region, term, false, "http://a0.awsstatic.com/pricing/1/ec2/mswin-ri-heavy.min.js");
+  return get_ec2_ri_price(type, region, term, false, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/windows-shared.min.js", "allUpfront");
 }
 
 /**
@@ -58,7 +58,7 @@ function EC2_WINDOWS_RI_HEAVY_AD(type, region, term) {
  */
 function EC2_WINDOWS_RI_LIGHT_HOUR(type, region, term) {
   if(!term) term = 1
-  return get_ec2_ri_price(type, region, term, true, "http://a0.awsstatic.com/pricing/1/ec2/mswin-ri-light.min.js");
+  return get_ec2_ri_price(type, region, term, true, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/windows-shared.min.js", "noUpfront");
 }
 
 /**
@@ -71,7 +71,7 @@ function EC2_WINDOWS_RI_LIGHT_HOUR(type, region, term) {
  */
 function EC2_WINDOWS_RI_MEDIUM_HOUR(type, region, term) {
   if(!term) term = 1
-  return get_ec2_ri_price(type, region, term, true, "http://a0.awsstatic.com/pricing/1/ec2/mswin-ri-medium.min.js");
+  return get_ec2_ri_price(type, region, term, true, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/windows-shared.min.js", "partialUpfront");
 }
 
 /**
@@ -84,5 +84,5 @@ function EC2_WINDOWS_RI_MEDIUM_HOUR(type, region, term) {
  */
 function EC2_WINDOWS_RI_HEAVY_HOUR(type, region, term) {
   if(!term) term = 1
-  return get_ec2_ri_price(type, region, term, true, "http://a0.awsstatic.com/pricing/1/ec2/mswin-ri-heavy.min.js");
+  return get_ec2_ri_price(type, region, term, true, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/windows-shared.min.js", "allUpfront");
 }

--- a/ec2.gs
+++ b/ec2.gs
@@ -1,47 +1,40 @@
 function get_ec2_od_price(type, region, url) {
-  var data = eval(getPriceData(url));
-  var regions = data['config']['regions'];
-  for (var i = 0; i < regions.length; i++) {
-    if(regions[i]['region'] == getOdRegion(region)) {
-      var instypes = regions[i]['instanceTypes'];
-      for (var j = 0; j < instypes.length; j++) {
-        var sizes = instypes[j]['sizes'];
-        for (var k = 0; k < sizes.length; k++) {
-          var size = sizes[k]['size'];
-          if(size == type) {
-            return sizes[k]['valueColumns'][0]['prices']['USD'];
-          }
-        }
-      }
-    }
-  }
+  return get_ec2_price(type, region, 1, null, url, "onDemandHourly", "ODHourly");
 }
 
-function get_ec2_ri_price(type, region, term, is_hourly, url) {
+function get_ec2_ri_price(type, region, term, is_hourly, url, purchaseOption) {
+  return get_ec2_price(type, region, term, is_hourly, url, "purchaseOptions", purchaseOption);
+}
+
+function get_ec2_price(type, region, term, is_hourly, url, termType, purchaseOption) {
   var data = eval(getPriceData(url));
   var regions = data['config']['regions'];
   for (var i = 0; i < regions.length; i++) {
     if(regions[i]['region'] == getRiRegion(region)) {
       var instypes = regions[i]['instanceTypes'];
       for (var j = 0; j < instypes.length; j++) {
-        var sizes = instypes[j]['sizes'];
-        for (var k = 0; k < sizes.length; k++) {
-          var valueColumns = sizes[k]['valueColumns'];
-          var size = sizes[k]['size'];
-          if(size == type) {
-            for (var l = 0; l < valueColumns.length; l++) {
-              var priceName = valueColumns[l]['name'];
-              if(priceName == "yrTerm1" && term == 1 && !is_hourly) {
-                return valueColumns[l]['prices']['USD'];
-              }
-              if(priceName == "yrTerm1Hourly" && term == 1 && is_hourly) {
-                return valueColumns[l]['prices']['USD'];
-              }
-              if(priceName == "yrTerm3" && term == 3 && !is_hourly) {
-                return valueColumns[l]['prices']['USD'];
-              }
-              if(priceName == "yrTerm3Hourly" && term == 3 && is_hourly) {
-                return valueColumns[l]['prices']['USD'];
+        if(instypes[j]['type'] == type) {
+          var terms = instypes[j]['terms'];
+          for (var l = 0; l < terms.length; l++) {
+            if((terms[l]['term'] == "yrTerm1" && term == 1)
+               || (terms[l]['term'] == "yrTerm3" && term == 3)) {
+              var purchaseOptions = terms[l][termType]
+              for (var k = 0; k < purchaseOptions.length; k++) {
+                if (purchaseOptions[k]['purchaseOption'] == purchaseOption) {
+                  if (is_hourly == null) {
+                    return parseFloat(purchaseOptions[k]['prices']['USD']);
+                  }
+
+                  var valueColumns = purchaseOptions[k]['valueColumns'];
+                  for (var m = 0; m < valueColumns.length; m++) {
+                    if (is_hourly && valueColumns[m]['name'] == "effectiveHourly") {
+                      return parseFloat(valueColumns[m]['prices']['USD']);
+                    }
+                    if (!is_hourly && valueColumns[m]['name'] == "upfront") {
+                      return parseFloat(valueColumns[m]['prices']['USD']);
+                    }
+                  }
+                }
               }
             }
           }

--- a/ec2_linux.gs
+++ b/ec2_linux.gs
@@ -6,7 +6,7 @@
  * @customfunction
  */
 function EC2_LINUX_OD(type, region) {
-  return get_ec2_od_price(type, region, "http://a0.awsstatic.com/pricing/1/ec2/linux-od.min.js");
+  return get_ec2_od_price(type, region, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/linux-unix-shared.min.js");
 }
 
 /**
@@ -19,7 +19,7 @@ function EC2_LINUX_OD(type, region) {
  */
 function EC2_LINUX_RI_LIGHT_AD(type, region, term) {
   if(!term) term = 1
-  return get_ec2_ri_price(type, region, term, false, "http://a0.awsstatic.com/pricing/1/ec2/linux-ri-light.min.js");
+  return get_ec2_ri_price(type, region, term, false, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/linux-unix-shared.min.js", "noUpfront");
 }
 
 /**
@@ -32,7 +32,7 @@ function EC2_LINUX_RI_LIGHT_AD(type, region, term) {
  */
 function EC2_LINUX_RI_MEDIUM_AD(type, region, term) {
   if(!term) term = 1
-  return get_ec2_ri_price(type, region, term, false, "http://a0.awsstatic.com/pricing/1/ec2/linux-ri-medium.min.js");
+  return get_ec2_ri_price(type, region, term, false, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/linux-unix-shared.min.js", "partialUpfront");
 }
 
 /**
@@ -45,7 +45,7 @@ function EC2_LINUX_RI_MEDIUM_AD(type, region, term) {
  */
 function EC2_LINUX_RI_HEAVY_AD(type, region, term) {
   if(!term) term = 1
-  return get_ec2_ri_price(type, region, term, false, "http://a0.awsstatic.com/pricing/1/ec2/linux-ri-heavy.min.js");
+  return get_ec2_ri_price(type, region, term, false, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/linux-unix-shared.min.js", "allUpfront");
 }
 
 /**
@@ -58,7 +58,7 @@ function EC2_LINUX_RI_HEAVY_AD(type, region, term) {
  */
 function EC2_LINUX_RI_LIGHT_HOUR(type, region, term) {
   if(!term) term = 1
-  return get_ec2_ri_price(type, region, term, true, "http://a0.awsstatic.com/pricing/1/ec2/linux-ri-light.min.js");
+  return get_ec2_ri_price(type, region, term, true, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/linux-unix-shared.min.js", "noUpfront");
 }
 
 /**
@@ -71,7 +71,7 @@ function EC2_LINUX_RI_LIGHT_HOUR(type, region, term) {
  */
 function EC2_LINUX_RI_MEDIUM_HOUR(type, region, term) {
   if(!term) term = 1
-  return get_ec2_ri_price(type, region, term, true, "http://a0.awsstatic.com/pricing/1/ec2/linux-ri-medium.min.js");
+  return get_ec2_ri_price(type, region, term, true, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/linux-unix-shared.min.js", "partialUpfront");
 }
 
 /**
@@ -84,5 +84,5 @@ function EC2_LINUX_RI_MEDIUM_HOUR(type, region, term) {
  */
 function EC2_LINUX_RI_HEAVY_HOUR(type, region, term) {
   if(!term) term = 1
-  return get_ec2_ri_price(type, region, term, true, "http://a0.awsstatic.com/pricing/1/ec2/linux-ri-heavy.min.js");
+  return get_ec2_ri_price(type, region, term, true, "https://a0.awsstatic.com/pricing/1/ec2/ri-v2/linux-unix-shared.min.js",  "allUpfront");
 }


### PR DESCRIPTION
I have upgraded EC2 functions to new pricing.
Note that I have used this library: http://ramblings.mcpher.com/Home/excelquirks/dbabstraction/dbcaching
As EC2 pricing JS are now over 100KB, we cannot cache it into a single value.